### PR TITLE
Add safe string expressions to format strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Latest additions:
 - **not restricted to KSampler**: can be adapted to any process generating images
 - **many configuration options**:
   - custom row/col headers, with string templating
-    - safe string expressions are supported for slicing and cleanup, for example `{dim1[:20]}` or `{dim1.replace("C:/models/", "")}`
+    - safe expressions are supported in XY Plot and Format String nodes:
+      - `{dim1[:20]}` — first 20 characters
+      - `{dim1[10:]}` — remove the first 10 characters
+      - `{dim1.replace("C:/models/", "")}` — remove a specific string or path
+      - `{dim1.removeprefix("epoch_")}` — remove a matching prefix
+      - `{dim1.removesuffix(".safetensors")}` — remove a matching suffix
   - font (type / size / color)
     - in row / column headers, and/or page header / footer (each configurable differently)
     - either one of the 4 fonts shipped with the extension, or any other TTF font on your disk

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Latest additions:
 - **not restricted to KSampler**: can be adapted to any process generating images
 - **many configuration options**:
   - custom row/col headers, with string templating
+    - safe string expressions are supported for slicing and cleanup, for example `{dim1[:20]}` or `{dim1.replace("C:/models/", "")}`
   - font (type / size / color)
     - in row / column headers, and/or page header / footer (each configurable differently)
     - either one of the 4 fonts shipped with the extension, or any other TTF font on your disk

--- a/src/python/nodes/plot.py
+++ b/src/python/nodes/plot.py
@@ -192,14 +192,14 @@ class XYPlotRender:
                     'STRING',
                     {
                         'default': '{dim1}',
-                        'tooltip': "template text to be displayed as dim1 header.\nthe '{dim1'} placeholder will be replaced by the current value.\nUse '\\n' for multiline text.",
+                        'tooltip': "template text to be displayed as dim1 header.\nthe '{dim1}' placeholder will be replaced by the current value.\nSafe expressions include {dim1[:20]}; string replacement is also supported.\nUse '\\n' for multiline text.",
                     },
                 ),
                 'dim2_header_format': (
                     'STRING',
                     {
                         'default': '{dim2}',
-                        'tooltip': "template text to be displayed as dim2 header.\nthe '{dim2'} placeholder will be replaced by the current value.\nUse '\\n' for multiline text.",
+                        'tooltip': "template text to be displayed as dim2 header.\nthe '{dim2}' placeholder will be replaced by the current value.\nSafe expressions include {dim2[:20]}; string replacement is also supported.\nUse '\\n' for multiline text.",
                     },
                 ),
                 'direction': (

--- a/src/python/nodes/utils.py
+++ b/src/python/nodes/utils.py
@@ -12,6 +12,7 @@ import comfy.utils
 
 from ..collection.register_nodes import register_node
 from ..shared.utils import ANY_TYPE, pillow_to_tensor
+from ..shared.formatting import format_string
 
 
 @register_node('Format: String', 'utils')
@@ -32,7 +33,7 @@ class FormatString:
                     {
                         'default': 'first arg by name: {arg0}, second by index: {1}',
                         'multiline': False,
-                        'tooltip': "placeholders can be either '{arg0}', '{arg1}, ... or '{0}', '{1}', ...",
+                        'tooltip': "placeholders can be either '{arg0}', '{arg1}', ... or '{0}', '{1}', ...; string expressions such as {arg0[:20]} and replace(...) are also supported",
                     },
                 ),
             }
@@ -48,11 +49,11 @@ class FormatString:
     FUNCTION = 'run'
     RETURN_TYPES = ('STRING',)
     RETURN_NAMES = ('formatted',)
-    DESCRIPTION = "Format a string, with any number of inputs.\nPlaceholders can be either '{arg0}', '{arg1}, ... or '{0}', '{1}', ...\nInputs can be strings, integers, floats, booleans.\nSearch for 'python format' for all configuration options, there are many!"
+    DESCRIPTION = "Format a string, with any number of inputs.\nPlaceholders can be either '{arg0}', '{arg1}', ... or '{0}', '{1}', ...\nString expressions support slicing and cleanup, for example '{arg0[:20]}' or '{arg0.replace(\"old\", \"\")}'.\nInputs can be strings, integers, floats, booleans.\nSearch for 'python format' for all configuration options, there are many!"
 
     def run(self, format: str, **kw):
         # handle both index and name references
-        output = format.format(*kw.values(), **kw)
+        output = format_string(format, *kw.values(), **kw)
 
         return (output,)
 
@@ -75,7 +76,7 @@ class FormatMultiline:
                     {
                         'default': 'first arg by name: {arg0}\nsecond by index: {1}',
                         'multiline': True,
-                        'tooltip': "placeholders can be either '{arg0}', '{arg1}, ... or '{0}', '{1}', ...",
+                        'tooltip': "placeholders can be either '{arg0}', '{arg1}', ... or '{0}', '{1}', ...; string expressions such as {arg0[:20]} and replace(...) are also supported",
                     },
                 ),
             }
@@ -91,11 +92,11 @@ class FormatMultiline:
     FUNCTION = 'run'
     RETURN_TYPES = ('STRING',)
     RETURN_NAMES = ('formatted',)
-    DESCRIPTION = "Format a multiline string, with any number of inputs.\nPlaceholders can be either '{arg0}', '{arg1}, ... or '{0}', '{1}', ...\nInputs can be strings, integers, floats, booleans."
+    DESCRIPTION = "Format a multiline string, with any number of inputs.\nPlaceholders can be either '{arg0}', '{arg1}', ... or '{0}', '{1}', ...\nString expressions support slicing and cleanup, for example '{arg0[:20]}' or '{arg0.replace(\"old\", \"\")}'.\nInputs can be strings, integers, floats, booleans."
 
     def run(self, format: str, **kw):
         # handle both index and name references
-        output = format.format(*kw.values(), **kw)
+        output = format_string(format, *kw.values(), **kw)
 
         return (output,)
 

--- a/src/python/shared/formatting.py
+++ b/src/python/shared/formatting.py
@@ -1,0 +1,255 @@
+"""Safe extensions for the Python format-string mini-language.
+
+The standard ``str.format`` syntax is retained.  This formatter additionally
+supports a small set of string expressions inside replacement fields, for
+example ``{dim1[:20]}`` or
+``{dim1.replace('C:/models/loras/', '')}``.
+
+Expressions are deliberately restricted to indexing, slicing, and a small
+allow-list of string methods.  They are not evaluated as arbitrary Python.
+"""
+
+import ast
+import re
+import string
+from typing import Any
+
+
+_POSITIONAL_ROOT = re.compile(r'^(\d+)(.*)$')
+_EXPRESSION_METHODS = {
+    'replace': (2, 3),
+    'removeprefix': (1, 1),
+    'removesuffix': (1, 1),
+    'strip': (0, 1),
+    'lstrip': (0, 1),
+    'rstrip': (0, 1),
+    'lower': (0, 0),
+    'upper': (0, 0),
+}
+
+
+class _SafeFormatter(string.Formatter):
+    @staticmethod
+    def _normalize_positional_root(field_name: str) -> str:
+        match = _POSITIONAL_ROOT.match(field_name)
+        if not match or not match.group(2):
+            return field_name
+        return f'arg{match.group(1)}{match.group(2)}'
+
+    def _evaluate(self, node: ast.AST, args, kwargs) -> Any:
+        if isinstance(node, ast.Name):
+            if node.id in kwargs:
+                return kwargs[node.id]
+            if node.id.startswith('arg') and node.id[3:].isdigit():
+                index = int(node.id[3:])
+                return args[index]
+            raise KeyError(node.id)
+
+        if isinstance(node, ast.Constant) and isinstance(
+            node.value, (str, int, float, bool, type(None))
+        ):
+            return node.value
+
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+            value = self._evaluate(node.operand, args, kwargs)
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError('unary signs are only allowed on numbers')
+            return -value if isinstance(node.op, ast.USub) else value
+
+        if isinstance(node, ast.Subscript):
+            value = self._evaluate(node.value, args, kwargs)
+            key = self._evaluate_slice(node.slice, args, kwargs)
+            return value[key]
+
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            value = self._evaluate(node.func.value, args, kwargs)
+            method = node.func.attr
+            if not isinstance(value, str) or method not in _EXPRESSION_METHODS:
+                raise ValueError(f"string method '{method}' is not allowed")
+            if node.keywords:
+                raise ValueError('keyword arguments are not allowed')
+            method_args = [self._evaluate(argument, args, kwargs) for argument in node.args]
+            min_args, max_args = _EXPRESSION_METHODS[method]
+            if not min_args <= len(method_args) <= max_args:
+                raise ValueError(
+                    f"string method '{method}' expects {min_args} to {max_args} arguments"
+                )
+            if method in {'replace', 'removeprefix', 'removesuffix', 'strip', 'lstrip', 'rstrip'}:
+                if not all(isinstance(argument, str) for argument in method_args[:2]):
+                    raise TypeError(f"string method '{method}' expects string arguments")
+            return getattr(value, method)(*method_args)
+
+        raise ValueError('only indexing, slicing, and approved string methods are allowed')
+
+    def _evaluate_slice(self, node: ast.AST, args, kwargs):
+        if isinstance(node, ast.Slice):
+            return slice(
+                self._evaluate_optional(node.lower, args, kwargs),
+                self._evaluate_optional(node.upper, args, kwargs),
+                self._evaluate_optional(node.step, args, kwargs),
+            )
+        return self._evaluate(node, args, kwargs)
+
+    def _evaluate_optional(self, node: ast.AST | None, args, kwargs):
+        return None if node is None else self._evaluate(node, args, kwargs)
+
+    def vformat(self, format_string, args, kwargs):
+        rewritten, expressions = _rewrite_expression_fields(format_string)
+        if not expressions:
+            return super().vformat(format_string, args, kwargs)
+
+        # Put lazy values into a private copy so the normal Formatter can still
+        # handle alignment, numeric formats, conversions, and escaped braces.
+        format_kwargs = dict(kwargs)
+        for name, expression in expressions.items():
+            format_kwargs[name] = _LazyExpression(self, expression, args, format_kwargs)
+        return super().vformat(rewritten, args, format_kwargs)
+
+
+class _LazyExpression:
+    def __init__(self, formatter, expression, args, kwargs):
+        self.formatter = formatter
+        self.expression = expression
+        self.args = args
+        self.kwargs = kwargs
+
+    def __format__(self, format_spec):
+        try:
+            expression = self.formatter._normalize_positional_root(self.expression)
+            tree = ast.parse(expression, mode='eval').body
+            value = self.formatter._evaluate(tree, self.args, self.kwargs)
+            return format(value, format_spec)
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError, SyntaxError) as error:
+            raise ValueError(
+                f"Invalid format expression '{{{self.expression}}}': {error}"
+            ) from error
+
+
+def _rewrite_expression_fields(template: str) -> tuple[str, dict[str, str]]:
+    """Replace extended fields with normal fields before Formatter parses them.
+
+    Python's Formatter treats every top-level colon as the start of a format
+    specifier.  Scanning the field ourselves lets expressions contain colons
+    inside slices and quoted Windows paths.
+    """
+    output = []
+    expressions = {}
+    index = 0
+    expression_index = 0
+    while index < len(template):
+        if template.startswith('{{', index) or template.startswith('}}', index):
+            output.append(template[index : index + 2])
+            index += 2
+            continue
+        if template[index] != '{':
+            output.append(template[index])
+            index += 1
+            continue
+
+        end = _find_field_end(template, index + 1)
+        if end is None:
+            output.append(template[index])
+            index += 1
+            continue
+
+        body = template[index + 1 : end]
+        expression, format_spec = _split_expression_format_spec(body)
+        if _is_extended_expression(expression):
+            name = f'__comfylab_expression_{expression_index}'
+            expression_index += 1
+            expressions[name] = expression
+            output.append('{')
+            output.append(name)
+            if format_spec:
+                output.extend((':', format_spec))
+            output.append('}')
+        else:
+            output.append(template[index : end + 1])
+        index = end + 1
+    return ''.join(output), expressions
+
+
+def _is_extended_expression(expression: str) -> bool:
+    if '(' in expression:
+        return True
+    bracket_depth = 0
+    quote = None
+    escaped = False
+    for character in expression:
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == '\\':
+                escaped = True
+            elif character == quote:
+                quote = None
+        elif character in "'\"":
+            quote = character
+        elif character == '[':
+            bracket_depth += 1
+        elif character == ']':
+            bracket_depth -= 1
+        elif character == ':' and bracket_depth:
+            return True
+    return False
+
+
+def _find_field_end(template: str, start: int) -> int | None:
+    quote = None
+    escaped = False
+    nesting = 0
+    for index in range(start, len(template)):
+        character = template[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == '\\':
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in "'\"":
+            quote = character
+        elif character in '[(':
+            nesting += 1
+        elif character in '])':
+            nesting -= 1
+        elif character == '{':
+            nesting += 1
+        elif character == '}' and nesting == 0:
+            return index
+        elif character == '}':
+            nesting -= 1
+    return None
+
+
+def _split_expression_format_spec(body: str) -> tuple[str, str]:
+    quote = None
+    escaped = False
+    nesting = 0
+    for index, character in enumerate(body):
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == '\\':
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in "'\"":
+            quote = character
+        elif character in '[(':
+            nesting += 1
+        elif character in '])':
+            nesting -= 1
+        elif character == ':' and nesting == 0:
+            return body[:index], body[index + 1 :]
+    return body, ''
+
+
+_FORMATTER = _SafeFormatter()
+
+
+def format_string(template: str, *args, **kwargs) -> str:
+    """Format a template using standard formatting plus safe string expressions."""
+    return _FORMATTER.vformat(template, args, kwargs)

--- a/src/python/shared/grid.py
+++ b/src/python/shared/grid.py
@@ -5,6 +5,7 @@ import math
 from dataclasses import asdict
 
 from .plot_data import PlotConfigGridData, PlotConfigHFData, PlotVars
+from .formatting import format_string
 
 STATIC_DIR = (Path(__file__).parent.parent.parent.parent / 'static').resolve()
 
@@ -273,7 +274,7 @@ class Grid:
     def _apply_template(self, template: str, plot_vars: PlotVars) -> str:
         text = template.replace(r'\n', '\n')
         try:
-            text = text.format(**asdict(plot_vars))
+            text = format_string(text, **asdict(plot_vars))
         except KeyError as e:
             text = "Error: unknown variable '{}'".format(e.args[0])
         return text

--- a/src/python/shared/pager.py
+++ b/src/python/shared/pager.py
@@ -8,6 +8,7 @@ from .plot_data import (
     PlotVars,
 )
 from .grid import Grid
+from .formatting import format_string
 
 
 class Pager:
@@ -56,11 +57,11 @@ class Pager:
         # TODO: catch exception and set default header?
         if xy_plot_data.dim1.index >= len(self.dim1.headers):
             self.dim1.headers.append(
-                self.header_formats[0].format(dim1=xy_plot_data.dim1.value)
+                format_string(self.header_formats[0], dim1=xy_plot_data.dim1.value)
             )
         if xy_plot_data.dim2.index >= len(self.dim2.headers):
             self.dim2.headers.append(
-                self.header_formats[1].format(dim2=xy_plot_data.dim2.value)
+                format_string(self.header_formats[1], dim2=xy_plot_data.dim2.value)
             )
 
         # store the tensor as image

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,37 @@
+import unittest
+
+from src.python.shared.formatting import format_string
+
+
+class FormatStringExpressionTests(unittest.TestCase):
+    def test_slice_expression(self):
+        self.assertEqual(format_string('{dim1[:5]}', dim1='abcdef'), 'abcde')
+        self.assertEqual(format_string('{dim1[2:]}', dim1='abcdef'), 'cdef')
+
+    def test_replace_expression_accepts_windows_paths(self):
+        self.assertEqual(
+            format_string(
+                '{dim1.replace("J:/models/loras/", "")}',
+                dim1='J:/models/loras/epoch_04.safetensors',
+            ),
+            'epoch_04.safetensors',
+        )
+
+    def test_prefix_suffix_and_existing_formats(self):
+        self.assertEqual(
+            format_string('{dim1.removeprefix("epoch_")}', dim1='epoch_04'),
+            '04',
+        )
+        self.assertEqual(
+            format_string('{dim1.removesuffix(".safetensors")}', dim1='epoch.safetensors'),
+            'epoch',
+        )
+        self.assertEqual(format_string('{dim2[1]:g}', dim2=('weight', 1.4)), '1.4')
+
+    def test_unsupported_expression_is_rejected(self):
+        with self.assertRaises(ValueError):
+            format_string('{dim1.replace("old")}', dim1='old')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wiki/node reference/format.md
+++ b/wiki/node reference/format.md
@@ -12,6 +12,10 @@ They are useful to create a string from a template, and **any number of inputs**
 > [!NOTE]
 > Inputs can be of the following ComfyUI types: `STRING`, `INT`, `FLOAT`, `BOOLEAN`.
 
+In addition to the standard Python format syntax, this extension supports a
+small safe expression syntax for string values. This is also available in XY
+Plot header formats.
+
 ## How to use
 
 Here we will just cover the most basic usage, but please note that Python string `format()` allows to do very interesting things, beyond the standard string replacement: padding, truncating, ...
@@ -27,6 +31,22 @@ Straightforward, isn't it?
 
 > [!TIP]
 > This way, it's **very simple to concatenate 2 strings, append text to a string, pad / truncate, ... many operations in one single node!**
+
+### String expressions
+
+The following expressions can be used inside a placeholder:
+
+| expression | result |
+| :--- | :--- |
+| `{arg0[:20]}` | first 20 characters |
+| `{arg0[10:]}` | everything after the first 10 characters |
+| `{arg0.replace("old", "new")}` | replace a specific string |
+| `{arg0.removeprefix("prefix_")}` | remove a matching prefix |
+| `{arg0.removesuffix(".png")}` | remove a matching suffix |
+
+Only indexing, slicing, and approved string methods are accepted; arbitrary
+Python expressions are not evaluated. Existing format specifications continue
+to work, such as `{arg1:g}` or `{arg0:.20s}`.
 
 And last but not least: at stated above, it can take **other types than strings: integer, float, boolean** (and surely others).
 

--- a/wiki/node reference/xy plot/1 - queue and render.md
+++ b/wiki/node reference/xy plot/1 - queue and render.md
@@ -49,6 +49,12 @@ For more detailed explanations, please check the [core concepts](./0%20-%20core%
 
 - enter here a template string, following the syntax of Python string `format()` method
 - the `{dim1}` and `{dim2}` placeholders will be replaced by the current dim1 / dim2 value
+- safe string expressions can trim or clean values directly inside the placeholder:
+  - `{dim1[:20]}` keeps the first 20 characters
+  - `{dim1[10:]}` removes the first 10 characters
+  - `{dim1.replace("C:/models/", "")}` removes a specific string
+  - `{dim1.removeprefix("epoch_")}` and `{dim1.removesuffix(".safetensors")}` remove only a matching prefix or suffix
+  - use forward slashes in paths, or escape Windows backslashes, for example `J:\\models\\loras\\`
 - very handy if you want to prefix the row / column headers, for example:
   - if you have CFG values in dim1, by default the headers will be `7.5`, `8`, ...
   - just change the dim1 header format to `CFG: {dim1}` and you will get: `CFG: 7.5`, `CFG: 8`, ...


### PR DESCRIPTION
## Summary

Adds a small, safe expression layer to the existing Python-style formatter. This lets XY Plot headers and Format String nodes trim or clean string values directly inside the placeholder.

Examples:

- `{dim1[:20]}` keeps the first 20 characters
- `{dim1[10:]}` removes the first 10 characters
- `{dim1.replace("C:/models/", "")}` removes a path/string fragment
- `{dim1.removeprefix("epoch_")}` and `{dim1.removesuffix(".safetensors")}` clean matching edges

Existing format specifications such as `{dim2[1]:g}` and `{dim1:.20s}` remain supported. Expressions are restricted to indexing, slicing, and approved string methods; arbitrary Python is not evaluated.

Documentation and focused unit tests are included.

## Validation

- `python -m unittest discover -s tests -v`
- `python -m py_compile` on the changed Python modules
- `git diff --check`